### PR TITLE
build: run all pre-commit hooks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,8 +40,7 @@ jobs:
 
       - name: Lint with Mypy and Flake8
         run: |
-          pdm run pre-commit run --all mypy
-          pdm run pre-commit run --all ruff
+          pdm run pre-commit run --all
 
   build:
     needs: [lint]
@@ -77,7 +76,7 @@ jobs:
         uses: coverallsapp/github-action@3dfc5567390f6fa9267c0ee9c251e4c8c3f18949 # v2.2.3
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          path-to-lcov: "./coverage.lcov"
+          file: "./coverage.lcov"
           parallel: true
           flag-name: run-${{ matrix.os }}-python-${{ matrix.python-version }}
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,11 +13,6 @@ repos:
         args: [--fix]
       - id: ruff-format
 
-  - repo: 'https://github.com/psf/black'
-    rev: 24.4.0
-    hooks:
-      - id: black
-
   - repo: local
     hooks:
       - id: mypy


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Removed the `ruff` command from the linting step in the CI workflow.
	- Updated the configuration for coverage reporting in the CI workflow.
	- Removed the Black formatter from the pre-commit configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->